### PR TITLE
Check conflict on create

### DIFF
--- a/exe/sumomo
+++ b/exe/sumomo
@@ -34,7 +34,7 @@ cmd_opts = case cmd
              local_opts = Trollop.options do
                opt :filename, 'File that describes the stack', type: :string, default: 'Sumomofile'
              end
-             Sumomo.create_stack(name: ARGV[0], region: global_opts[:region]) do
+             Sumomo.send("#{cmd}_stack", name: ARGV[0], region: global_opts[:region]) do
                proc = proc {}
                eval File.read(local_opts[:filename]), proc.binding, local_opts[:filename]
              end

--- a/lib/sumomo.rb
+++ b/lib/sumomo.rb
@@ -259,7 +259,4 @@ module Sumomo
 
     map
   end
-
-  singleton_class.send(:alias_method, :create_stack, :create_stack)
-  singleton_class.send(:alias_method, :update_stack, :update_stack)
 end

--- a/lib/sumomo.rb
+++ b/lib/sumomo.rb
@@ -26,6 +26,16 @@ module Sumomo
     "cloudformation/#{make_master_key_name(name: name)}.pem"
   end
 
+  def self.create_stack(name:, region:, sns_arn: nil, &block)
+    cf = Aws::CloudFormation::Client.new(region: region)
+    begin
+      cf.describe_stacks(stack_name: name)
+      raise "There is already a stack named '#{name}'"
+    rescue Aws::CloudFormation::Errors::ValidationError
+      update_stack(name: name, region: region, sns_arn: sns_arn, &block)
+    end
+  end
+
   def self.update_stack(name:, region:, sns_arn: nil, &block)
     cf = Aws::CloudFormation::Client.new(region: region)
     s3 = Aws::S3::Client.new(region: region)
@@ -250,5 +260,6 @@ module Sumomo
     map
   end
 
-  singleton_class.send(:alias_method, :create_stack, :update_stack)
+  singleton_class.send(:alias_method, :create_stack, :create_stack)
+  singleton_class.send(:alias_method, :update_stack, :update_stack)
 end


### PR DESCRIPTION
This PR enables checking on `create` command.

`sumomo create` will check if there is already a stack with same name and abort if it found one.

If name conflict is unintentional, it will destroy resources owned by the old stack. So it can be dangerous.
