### PR TITLE
Make script composable

### DIFF
--- a/exe/sumomo
+++ b/exe/sumomo
@@ -49,7 +49,7 @@ cmd_opts = case cmd
              key = JSON.parse(File.read('x.txt'))['value']
              File.write('key.pem', key)
              `chmod 0600 key.pem`
-             exec "ssh -i 'key.pem' ec2-user@#{ARGV[1]}"
+             exec "ssh -i 'key.pem' ec2-user@#{ARGV[1]} #{ARGV[2]}"
 
            when 'testapi'
              local_opts = Trollop.options do


### PR DESCRIPTION
Allows the `script` keyword to be composable, and lets security groups be added to an autoscaling group