### PR TITLE
Allow setting AWS_PROFILE env var

### DIFF
--- a/exe/sumomo
+++ b/exe/sumomo
@@ -19,7 +19,7 @@ global_opts = Optimist.options do
   stop_on SUB_COMMANDS
 end
 
-ENV['AWS_PROFILE'] = global_opts[:profile]
+ENV['AWS_PROFILE'] ||= global_opts[:profile]
 
 puts 'Using profile:'
 p ENV['AWS_PROFILE']

--- a/lib/sumomo/version.rb
+++ b/lib/sumomo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sumomo
-  VERSION = '0.10.8'
+  VERSION = '0.10.9'
 end


### PR DESCRIPTION
If I have a shell script that invokes `sumomo`, I currently have no way to set the `AWS_PROFILE` env var since sumomo overwrites it every time unless you pass it as an argument. This PR lets sumomo use `AWS_PROFILE` as-is.